### PR TITLE
pass reversestrategy from new Database property reverseStrategyClass

### DIFF
--- a/src/main/groovy/org/hibernate/gradle/tools/Database.groovy
+++ b/src/main/groovy/org/hibernate/gradle/tools/Database.groovy
@@ -60,4 +60,5 @@ class Database {
     String  basePackage = "com.project.database.model"
     String  revEngXml   = ""
     String  configXml   = ""
+    String  reverseStrategyClass = null
 }

--- a/src/main/groovy/org/hibernate/gradle/tools/Hbm2DaoTask.groovy
+++ b/src/main/groovy/org/hibernate/gradle/tools/Hbm2DaoTask.groovy
@@ -53,17 +53,23 @@ class Hbm2DaoTask  extends DefaultTask{
     }
 
     def hbm2dao(final Project project){
+        //reversestrategy must not be provided if it is null
+        def preparedJdbcConfiguration = [
+            configurationfile:  "${config.hibernateConfigXml.path}",
+            revengfile:         "${config.hibernateRevEngXml.path}",
+            packagename:        "${project.database.basePackage}"
+        ]
+        if (project.database.reverseStrategyClass != null) {
+            preparedJdbcConfiguration.reversestrategy = "${project.database.reverseStrategyClass}"
+        }
+        
         project.ant {
             taskdef(name: "hibernatetool",
                     classname: "org.hibernate.tool.ant.HibernateToolTask",
                     classpath: config.classPath
             )
             hibernatetool( destdir : config.javaSrcGeneratedDir ) {
-                jdbcconfiguration(
-                        configurationfile:  "${config.hibernateConfigXml.path}",
-                        revengfile:         "${config.hibernateRevEngXml.path}",
-                        packagename:        "${project.database.basePackage}"
-                )
+                jdbcconfiguration(preparedJdbcConfiguration)
                 hbm2dao(
                         jdk5: true,
                         ejb3: true

--- a/src/main/groovy/org/hibernate/gradle/tools/Hbm2JavaTask.groovy
+++ b/src/main/groovy/org/hibernate/gradle/tools/Hbm2JavaTask.groovy
@@ -51,17 +51,23 @@ class Hbm2JavaTask  extends DefaultTask{
     }
 
     def hbm2java(final Project project){
+        //reversestrategy must not be provided if it is null
+        def preparedJdbcConfiguration = [
+                configurationfile:  "${config.hibernateConfigXml.path}",
+                revengfile:         "${config.hibernateRevEngXml.path}",
+                packagename:        "${project.database.basePackage}"
+        ]
+        if (project.database.reverseStrategyClass != null) {
+            preparedJdbcConfiguration.reversestrategy = "${project.database.reverseStrategyClass}"
+        }
+        
         project.ant {
             taskdef(name: "hibernatetool",
                     classname: "org.hibernate.tool.ant.HibernateToolTask",
                     classpath: config.classPath
             )
             hibernatetool( destdir : config.javaSrcGeneratedDir, templatepath : 'templates' ) {
-                jdbcconfiguration(
-                        configurationfile:  "${config.hibernateConfigXml.path}",
-                        revengfile:         "${config.hibernateRevEngXml.path}",
-                        packagename:        "${project.database.basePackage}"
-                )
+                jdbcconfiguration(preparedJdbcConfiguration)
                 hbm2java(
                         jdk5: true,
                         ejb3: true

--- a/src/main/groovy/org/hibernate/gradle/tools/HibernatePlugin.groovy
+++ b/src/main/groovy/org/hibernate/gradle/tools/HibernatePlugin.groovy
@@ -45,7 +45,7 @@ class HibernatePlugin implements Plugin<Project>{
         project.repositories.mavenLocal()
         project.repositories.mavenCentral()
         project.afterEvaluate {
-            def configuration = project.configurations.create('reveng')
+            def configuration = project.configurations.maybeCreate('reveng')
             configuration.dependencies.add(project.dependencies.create('org.hibernate:hibernate-tools:5.2.0.Final'))
             configuration.dependencies.add(project.dependencies.create('org.slf4j:slf4j-simple:1.7.5'))
             configuration.extendsFrom(project.configurations.findByName('compile'))


### PR DESCRIPTION
Support passing the 'reversestrategy' parameter to ant, which refers to a class which can override some of the reverse-engineering strategy performed by Hibernate Tools.

A new property 'reverseStrategyClass' has been added to the Database class, defaulting to null. If it is not set it must not be passed to ant or it looks for a null class at runtime. I can't see a gradle way to optionally set a property so I'm now pre-defining a preparedJdbcConfiguration which can include a null check before setting the property.

The calling project needs to be able to add to this plugin's runtime classpath, which it could do in its dependencies section if the 'reveng' configuration were available. It won't be as it's not created until .afterEvaluate, so changing from configurations.create() to configurations.maybeCreate() allows the caller to define the configuration upfront.
